### PR TITLE
Remove trailing slash from charge capture URL.

### DIFF
--- a/server/methods/charges.js
+++ b/server/methods/charges.js
@@ -7,7 +7,7 @@ Stripe.charges.create = function(object) {
 		auth: Stripe.secretKey,
 		params: object
 	}
-	
+
 	return HTTP.call('POST', Stripe.baseUrl + 'charges', options).data;
 }
 
@@ -33,7 +33,7 @@ Stripe.charges.capture = function(id) {
 		auth: Stripe.secretKey
 	}
 
-	return HTTP.call('POST', Stripe.baseUrl + 'charges/' + id + '/capture/', options).data;
+	return HTTP.call('POST', Stripe.baseUrl + 'charges/' + id + '/capture', options).data;
 }
 
 Stripe.charges.list = function() {


### PR DESCRIPTION
When you attempt to capture a charge on Stripe, having a trailing slash on the URL causes Stripe to return a 404.

Removing the trailing slash fixes this.
